### PR TITLE
Adding a docker harness for us to work with locally

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -1,0 +1,21 @@
+# Working locally with Docker
+
+To introduce changes to this buildpack and have it tested locally before needing to use an heroku app
+you can use this docker harness.
+
+## Giving it a spin
+
+Simply start docker and run `docker compose run app bash`  
+This will build the local image - will take a bit.. - and launch you into a bash inside a container.  
+You can now copy any files into the `shared` folder as they will be available both on the host and the container.
+
+## Tweaking
+
+Lets say you made some changes to the buildpack and want the `compile` step to run again...  
+Well, you need to remove the image you previously built and build anew:
+
+```
+docker image rm heroku-im7-rsvg
+```
+
+NOTE: you can only delete images if there are no containers using it, so you may need to remove some containers too.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM heroku/heroku:20-build
+
+WORKDIR /app
+
+COPY . /buildpack
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /buildpack/bin/* /entrypoint.sh
+
+ENV STACK=heroku-20
+
+RUN /buildpack/bin/compile /app /cache /env
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/bin/compile
+++ b/bin/compile
@@ -80,9 +80,8 @@ EOF
 # update PATH and LD_LIBRARY_PATH
 echo "-----> Updating environment variables"
 PROFILE_PATH="$BUILD_DIR/.profile.d/imagemagick.sh"
-ACTUAL_INSTALL_PATH="$HOME/vendor/imagemagick"
 mkdir -p $(dirname $PROFILE_PATH)
-echo "export PATH=$ACTUAL_INSTALL_PATH/bin:\$PATH" >> $PROFILE_PATH
-echo "export LD_LIBRARY_PATH=$ACTUAL_INSTALL_PATH/lib:\$LD_LIBRARY_PATH:/usr/local/lib" >> $PROFILE_PATH
-echo "export MAGICK_CONFIGURE_PATH=$ACTUAL_INSTALL_PATH/etc/ImageMagick-7" >> $PROFILE_PATH
+echo "export PATH=$INSTALL_DIR/bin:\$PATH" >> $PROFILE_PATH
+echo "export LD_LIBRARY_PATH=$INSTALL_DIR/lib:\$LD_LIBRARY_PATH:/usr/local/lib" >> $PROFILE_PATH
+echo "export MAGICK_CONFIGURE_PATH=$INSTALL_DIR/etc/ImageMagick-7" >> $PROFILE_PATH
 echo "-----> Done updating environment variables. All set for ImageMagick."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: heroku-im7-rsvg
+    volumes:
+      - ./shared:/shared
+    command: bash
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for file in /app/.profile.d/*.sh; do
+  source $file
+done
+
+exec "$@"


### PR DESCRIPTION
This adds a simple docker harness so we can test changes to the buildpack BEFORE pushing to heroku or needing to occupy the staging machine for tests.