### PR TITLE
fix: key ImageMagick cache on stack, enforce TIFF support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,12 @@ CACHE_DIR=$2
 VENDOR_DIR="$BUILD_DIR/vendor"
 INSTALL_DIR="$VENDOR_DIR/imagemagick"
 IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-7.1.1-35}"
-CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
+# Key the cache on the stack as well as the version. ImageMagick is compiled
+# from source and links against the stack's system libs (e.g. libtiff), so a
+# binary built on heroku-22 (libtiff.so.5) will not load on heroku-24
+# (libtiff.so.6). Without $STACK in the key, a stack change re-serves the old
+# binary from cache and breaks at runtime.
+CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION-${STACK:-unknown}.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick
@@ -34,8 +39,18 @@ if [ ! -f $CACHE_FILE ]; then
   cd $IMAGE_MAGICK_DIR
   export CPPFLAGS="-I$INSTALL_DIR/include"
   export LDFLAGS="-L$INSTALL_DIR/lib"
-  ./configure --prefix=$INSTALL_DIR --with-rsvg=yes --with-png=yes
+  # --with-tiff=yes forces configure to fail if TIFF headers are missing,
+  # instead of silently building a binary without TIFF support (the print
+  # pipeline renders TIFFs, so a TIFF-less binary is a worse, quieter failure).
+  ./configure --prefix=$INSTALL_DIR --with-rsvg=yes --with-png=yes --with-tiff=yes
   make && make install
+
+  # Verify the produced binary actually loads and has TIFF before it gets
+  # cached and shipped — belt-and-suspenders against a bad build.
+  if ! "$INSTALL_DIR/bin/magick" -version | grep -q tiff; then
+    echo "Error: ImageMagick built without TIFF support" | indent
+    exit 1
+  fi
   cd ..
   rm -rf $IMAGE_MAGICK_DIR
 


### PR DESCRIPTION
### Summary

Fix a buildpack cache bug that shipped a broken ImageMagick binary after a Heroku stack upgrade, and add a guard so a TIFF-less build fails loudly instead of silently.

### Motivation

`black-cat-production` was unwittingly moved to the heroku-24 stack (a side effect of a deploy, not an intentional change), and every `RenderJob` began failing with:

```
magick: error while loading shared libraries: libtiff.so.5: cannot open shared object file
```

The buildpack compiles ImageMagick from source, so the binary links against the stack's system libs. heroku-22 ships `libtiff.so.5`; heroku-24 ships `libtiff.so.6`. Because the cache was keyed only on ImageMagick version, the post-upgrade build re-served the old heroku-22 binary from cache — which links `libtiff.so.5`, absent on heroku-24 — so `magick` couldn't load and all render jobs crashed.

Incident write-up: postpilot-org/technology-team#1230

### Implementation

- `bin/compile`: add `$STACK` to the cache key (`imagemagick-$VERSION-${STACK:-unknown}.tar.gz`) so a stack change forces a clean recompile instead of reusing a binary built against a different stack's libs.
- `bin/compile`: add `--with-tiff=yes` to `./configure` so a missing TIFF header fails the build rather than silently producing a TIFF-less binary (the print pipeline renders TIFFs).
- `bin/compile`: after `make install`, assert the built `magick` reports TIFF support before it gets cached.

### Impact

- A stack change now triggers a recompile against the new stack's libs — this class of "wrong libtiff soname" failure can't recur.
- `libtiff-dev` is present on the heroku-24 build image, so the recompile builds against `libtiff.so.6` correctly.
- Existing caches are invalidated (new key), so the next deploy on any consumer recompiles once.

### Risks

- First deploy after merge recompiles ImageMagick from source (slower build, one-time per stack).
- Consumers must purge any old cache / redeploy for the fix to take effect on a running app; the buildpack change alone does not rebuild a live slug.
