### PR TITLE
fix: download ImageMagick from the archive host that retains old releases

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -22,7 +22,10 @@ if [ ! -f $CACHE_FILE ]; then
   # install imagemagick
   IMAGE_MAGICK_FILE="ImageMagick-$IMAGE_MAGICK_VERSION.tar.xz"
   IMAGE_MAGICK_DIR="ImageMagick-$IMAGE_MAGICK_VERSION"
-  IMAGE_MAGICK_URL="https://www.imagemagick.org/download/releases/$IMAGE_MAGICK_FILE"
+  # download.imagemagick.org/archive/releases retains historical point releases;
+  # www.imagemagick.org/download/releases only serves the current one and 404s
+  # for older versions. (black-cat CI already pulls from this archive host.)
+  IMAGE_MAGICK_URL="https://download.imagemagick.org/archive/releases/$IMAGE_MAGICK_FILE"
 
   echo "-----> Downloading ImageMagick from $IMAGE_MAGICK_URL"
   wget $IMAGE_MAGICK_URL -P $BUILD_DIR | indent


### PR DESCRIPTION
Refs: https://github.com/postpilot-org/technology-team/issues/1230

### Summary

Point the ImageMagick download at `download.imagemagick.org/archive/releases`, which keeps historical point releases.

### Motivation

After #3 (stack-aware cache key) forced the first from-source recompile in a while, the build 404'd:

```
https://imagemagick.org/download/releases/ImageMagick-7.1.1-35.tar.xz → 404 Not Found
Push rejected, failed to compile ImageMagick app.
```

`www.imagemagick.org/download/releases` only serves the *current* release, so the pinned 7.1.1-35 no longer exists there. The stale cache had masked this — nothing re-downloaded until the cache key changed. (black-cat CI already pulls this exact version from the archive host without issue.)

### Implementation

- `bin/compile`: change `IMAGE_MAGICK_URL` host to `https://download.imagemagick.org/archive/releases/…`. Same version, same filename, same extraction logic — only the host changes.

### Impact

- A from-source build of the pinned version downloads successfully instead of 404ing.
- Unblocks the recompile that #3 correctly triggered.
